### PR TITLE
Specify the right role name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example Playbook
 ```
 - hosts: servers
   roles:
-     - { role: dell-firmware-upgrade }
+     - { role: ansible-role-dell-firmware-upgrade }
 ```
 License
 -------


### PR DESCRIPTION
If you install this role through requirements.yml without any renaming,
then the right role name to call is ansible-role-dell-firmware-upgrade -
not dell-firmware-upgrade. Update README.md to reflect this.
