### PR TITLE
added option to use proxy env where needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,19 @@ Role Variables
 --------------
 By default this role upgrades all firmwares.
 
+Define something like this to use a proxy when fetching the Dell bootstrap script
+<pre>
+proxy_server_address: "http://your_special_proxy :3128"
+proxy_env:
+  ftp_proxy: "{{proxy_server_address}}"
+  http_proxy: "{{proxy_server_address}}"
+  https_proxy: "{{proxy_server_address}}"
+</pre>
+
 Dependencies
 ------------
+
+ - wget
 
 Example Playbook
 ----------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Install Dell DSU repo 
+  environment: "{{proxy_env}}"
   shell: "wget -q -O - http://linux.dell.com/repo/hardware/dsu/bootstrap.cgi | bash"
   args:
      creates: /etc/yum.repos.d/dell-system-update

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install Dell DSU repo 
-  environment: "{{proxy_env}}"
+  environment: "{{proxy_env|default(omit)}}"
   shell: "wget -q -O - http://linux.dell.com/repo/hardware/dsu/bootstrap.cgi | bash"
   args:
      creates: /etc/yum.repos.d/dell-system-update


### PR DESCRIPTION
Add proper proxy env for your group_vars like this: 
proxy_server_address: "http://your_special_proxy :3128"
proxy_env:
    ftp_proxy: "{{proxy_server_address}}"
    http_proxy: "{{proxy_server_address}}"
    https_proxy: "{{proxy_server_address}}"