### PR TITLE
Fail if we can't wget |bash the bootstrap file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ after_script:
   - docker ps -a
   - docker stop $DOCKER_CONTAINER_ID
   - docker rm -v $DOCKER_CONTAINER_ID
-#after_success:
-#  - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+after_success:
+  - env
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ By default this role upgrades all firmwares.
 
 Define something like this to use a proxy when fetching the Dell bootstrap script
 <pre>
-proxy_server_address: "http://your_special_proxy :3128"
+proxy_server_address: "http://your_special_proxy:3128"
 proxy_env:
   ftp_proxy: "{{proxy_server_address}}"
   http_proxy: "{{proxy_server_address}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   environment: "{{proxy_env|default({})}}"
   shell: "wget -q -O - http://linux.dell.com/repo/hardware/dsu/bootstrap.cgi | bash"
   args:
-     creates: /etc/yum.repos.d/dell-system-update
+     creates: /etc/yum.repos.d/dell-system-update.repo
   tags: skip_ansible_lint
   register: reg_install_dsu_repo
   when: dell_dsu_repo_install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   tags: skip_ansible_lint
   register: reg_install_dsu_repo
   when: dell_dsu_repo_install
-  failed_when: "Done!" not in reg_install_dsu_repo.stdout
+  failed_when: "'Done!' not in reg_install_dsu_repo.stdout"
 
 - name: Install Dell DSU prerequisites
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,14 @@
 ---
 
 - name: Install Dell DSU repo
-  environment: "{{proxy_env|default(omit)}}"
+  environment: "{{proxy_env|default({})}}"
   shell: "wget -q -O - http://linux.dell.com/repo/hardware/dsu/bootstrap.cgi | bash"
   args:
      creates: /etc/yum.repos.d/dell-system-update
   tags: skip_ansible_lint
+  register: reg_install_dsu_repo
   when: dell_dsu_repo_install
+  failed_when: "Done!" not in reg_install_dsu_repo.stdout
 
 - name: Install Dell DSU prerequisites
   yum:
@@ -18,7 +20,9 @@
     - OpenIPMI
 
 - name: Installing Dell DSU RPM
-  yum: name=dell-system-update state=present
+  yum:
+    name: dell-system-update
+    state: present
 
 - name: Update firmware
   command: "dsu -n"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,12 @@
   tags: skip_ansible_lint
   register: reg_install_dsu_repo
   when: dell_dsu_repo_install
-  failed_when: "'Done!' not in reg_install_dsu_repo.stdout"
+  failed_when: "('Done!' not in reg_install_dsu_repo.stdout) and (reg_install_dsu_repo.rc != 0)"
+
+- name: print reg_install_dsu_repo variable if verbosity is 1
+  debug:
+    var: reg_install_dsu_repo
+    verbosity: 1
 
 - name: Install Dell DSU prerequisites
   yum:

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -122,8 +122,8 @@ function test_playbook(){
 }
 function extra_tests(){
 
-    echo "TEST: cat the resulting /etc/collectd.d/collectd.conf"
-    cat /etc/collectd.d/collectd.conf
+    echo "TEST: ls -la /etc/yum.repos.d/"
+    ls -la /etc/yum.repos.d/*
 }
 
 
@@ -138,7 +138,7 @@ function main(){
     test_playbook_syntax
     test_playbook
     test_playbook_check
-#    extra_tests
+    extra_tests
 
 }
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -116,6 +116,9 @@ function test_playbook(){
 
     echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
     ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
+
+    echo "TEST: idempotence test #2! Same as previous but show the output"
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} ||(echo "third ansible run failed" && exit 3 )
 }
 function extra_tests(){
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,8 +5,6 @@
    vars:
      - dell_dsu_repo_install: True
      - dell_dsu_update_all_firmware: False
-     - proxy_env:
-        http_proxy: "http://localhost:3128"
 
    roles:
      - ../ansible-role-dell-firmware-upgrade

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,6 +5,8 @@
    vars:
      - dell_dsu_repo_install: True
      - dell_dsu_update_all_firmware: False
+     - proxy_env:
+        http_proxy: "http://localhost:3128"
 
    roles:
      - ../ansible-role-dell-firmware-upgrade


### PR DESCRIPTION
 - Change default(omit) to default({}) in the wget | bash task
   - With this change the error (could not parse environment value proxy_env) about reported in #7 is gone
 - Add an extra failure scenario (in addition to normal failures (return code not 0)) on the wget|bash task:
   - Fail if the task does not output "Done!" to stdout
 - run "env" after for some extra travis debugging
 - if you run ansible-playbook with -v get the contents of the {{ reg_install_dsu_repo }} variable 
 - Fix the wget|bash task so that it don't run the bootstrap of the .repo file exists (it was missing a .repo at the end of the filename)