### PR TITLE
put prereqs and exit codes into var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,5 +11,11 @@ dell_dsu_update_all_firmware: True
 # Could be changed to for eaxmple only upgrade some categories with "--category=BI" 
 #  for BIOS updates only
 dell_dsu_arguments: "--non-interactive --apply-upgrades-only"
-
+dell_dsu_prerequisites:
+  - usbutils
+  - compat-libstdc++-33.i686
+  - OpenIPMI
+dell_dsu_exit_codes:
+  - 0
+  - 8
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,12 +17,8 @@
 
 - name: Install Dell DSU prerequisites
   yum:
-    name: "{{ item }}"
-    state: installed
-  with_items:
-    - usbutils
-    - compat-libstdc++-33.i686
-    - OpenIPMI
+    name: "{{ dell_dsu_prerequisites }}"
+    state: present
 
 - name: Installing Dell DSU RPM
   yum:
@@ -33,4 +29,4 @@
   command: "dsu {{ dell_dsu_arguments }}"
   when: dell_dsu_update_all_firmware
   register: command_result
-  failed_when: command_result.rc != 0 and command_result.rc != 8
+  failed_when: command_result.rc not in dell_dsu_exit_codes


### PR DESCRIPTION
This is a refactoring to make exit codes and prereq packages overwriteable


Reason prereq packages:
the currently defined packages do not seem necessary (at least on my rhel7 test systems)

Reason for exit codes:
if all updates are already installed dsu will give back exit code 1. I've created a bug with Dell about that but for now I have to accept exit code 1 as success aswell...