### PR TITLE
New exit code for "no new updates"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,4 +20,5 @@ dell_dsu_prerequisites:
 dell_dsu_exit_codes:
   - 0
   - 8
+  - 34
 ...


### PR DESCRIPTION
dsu 1.6.0 introduced a new exit code for "no new updates"