### PR TITLE
Generalize travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
-language: python
-
-sudo: required
-dist: trusty
-group: edge
+language: generic
 
 services:
   - docker


### PR DESCRIPTION
Similar to https://github.com/CSCfi/ansible-role-dell/pull/6

- Trusty has been deprecated, use the default (xenial at the moment).

- sudo is always available as the travis container-based
  infrastructure has been deprecated.

- group tag isn't necessary anymore either.

- Use language: generic as we're using docker for everything and not
  python.