### PR TITLE
Add another Dell device that needs to be blacklisted via multipathd

### DIFF
--- a/files/multipath_dell.conf
+++ b/files/multipath_dell.conf
@@ -26,4 +26,8 @@ blacklist {
                 vendor "iDRAC"
                 product "scrtch"
         }
+        device {
+                vendor "Linux"
+                product "scrtch"
+        }
 }


### PR DESCRIPTION
Dell has changed/added the vendor identification of another device. Adding it to multipath blacklist is needed.